### PR TITLE
Allows IsGreaterThanOrEqualTo(0)

### DIFF
--- a/src/validators/number-based/IsGreaterThanOrEqualToValidator.spec.ts
+++ b/src/validators/number-based/IsGreaterThanOrEqualToValidator.spec.ts
@@ -32,5 +32,29 @@ describe("IsGreaterThanOrEqualToValidator", () => {
 
             expect(result).toBeFalsy();
         });
+
+        describe("when threshold is 0", () => {
+            beforeEach(() => {
+                validator = new IsGreaterThanOrEqualToValidator(0);
+            });
+
+            it("should return true if given number is equal to the threshold value", () => {
+                let result = validator.isValid(0);
+
+                expect(result).toBeTruthy();
+            });
+
+            it("should return true if given number is greater than the threshold value", () => {
+                let result = validator.isValid(1);
+
+                expect(result).toBeTruthy();
+            });
+
+            it("should return false if given number is less than the threshold value", () => {
+                let result = validator.isValid(-1);
+
+                expect(result).toBeFalsy();
+            });
+        });
     });
 });

--- a/src/validators/number-based/IsGreaterThanOrEqualToValidator.ts
+++ b/src/validators/number-based/IsGreaterThanOrEqualToValidator.ts
@@ -13,9 +13,9 @@ export class IsGreaterThanOrEqualToValidator implements PropertyValidator<number
     }
 
     isValid(input: number | undefined): boolean {
-        if (input) {
-            return input >= this.threshold;
+        if (typeof input === "undefined" || input === null) {
+            return false;
         }
-        return false;
+        return input >= this.threshold;
     }
 }

--- a/src/validators/number-based/IsLessThanOrEqualToValidator.spec.ts
+++ b/src/validators/number-based/IsLessThanOrEqualToValidator.spec.ts
@@ -32,5 +32,29 @@ describe("IsLessThanOrEqualToValidator", () => {
 
             expect(result).toBeFalsy();
         });
+
+        describe("when threshold is 0", () => {
+            beforeEach(() => {
+                validator = new IsLessThanOrEqualToValidator(0);
+            });
+
+            it("should return true if given number is equal to the threshold value", () => {
+                let result = validator.isValid(0);
+
+                expect(result).toBeTruthy();
+            });
+
+            it("should return true if given number is less than the threshold value", () => {
+                let result = validator.isValid(-1);
+
+                expect(result).toBeTruthy();
+            });
+
+            it("should return false if given number is greater than the threshold value", () => {
+                let result = validator.isValid(1);
+
+                expect(result).toBeFalsy();
+            });
+        });
     });
 });


### PR DESCRIPTION
I found that `IsGreaterThanOrEqualTo` and `IsLessThanOrEqualTo` are handling `0` differently.  `IsLessThanOrEqualTo` will properly compare the input value `0` and will return truthy when 0 === 0. `IsGreaterThanOrEqualTo` will always return false if the input value is `0`.  

I have updated `IsGreaterThanOrEqualTo` to explicitly check for null or undefined like `IsLessThanOrEqualTo` does.